### PR TITLE
Adds a new menu item "Favorite Locations" in the navigation

### DIFF
--- a/static/js/custom.js.example
+++ b/static/js/custom.js.example
@@ -11,6 +11,13 @@ $(function () {
     const upscalePokemon = false // Enable upscaling of certain Pokemon (upscaledPokemon and notify list). Default: false.
     const upscaledPokemon = [] // Add Pokémon IDs separated by commas (e.g. [1, 2, 3]) to upscale icons. Default: [].
 
+    // Add predefined buttons for favorite location. Default: [].
+    const favoriteLocations = [
+        {
+            'Central Park (NY)': {lat: 40.7828647, lng: -73.9653551, zoom: 16, deletable: false}
+        }
+    ] 
+
     // Google Analytics property ID. Leave empty to disable.
     // Looks like 'UA-XXXXX-Y'.
     const analyticsKey = ''
@@ -81,7 +88,11 @@ $(function () {
 	Store.set('isSearchMarkerMovable', isSearchMarkerMovable)
     Store.set('showLocationMarker', showLocationMarker)
     Store.set('isLocationMarkerMovable', isLocationMarkerMovable)
-	
+
+        if (Store.get('favoriteLocations').length === 0) {
+        Store.set('favoriteLocations', favoriteLocations)
+    }
+
     if (typeof window.orientation !== 'undefined' || isMobileDevice()) {
         Store.set('maxClusterZoomLevel', maxClusterZoomLevelMobile)
         Store.set('clusterZoomOnClick', clusterZoomOnClickMobile)

--- a/static/js/map.common.js
+++ b/static/js/map.common.js
@@ -1101,6 +1101,10 @@ var StoreOptions = {
     'showMedalMagikarp': {
         default: false,
         type: StoreTypes.Boolean
+    },
+    'favoriteLocations': {
+        default: [],
+        type: StoreTypes.JSON
     }
 }
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3602,6 +3602,34 @@ $(function () {
         })
     }
 
+    // Favorite-location
+    // switch to display "Add this view"
+    $('#add-favorite-location-switch').change(function () {
+        var options = {
+            'duration': 500
+        }
+        var wrapper = $('#add-favorite-location-wrapper')
+        if (this.checked) {
+            wrapper.show(options)
+        } else {
+            wrapper.hide(options)
+        }
+    })
+
+    // Favorite-location
+    // switch to display "search location"
+    $('#search-favorite-location-switch').change(function () {
+        var options = {
+            'duration': 500
+        }
+        var wrapper = $('#search-favorite-location-wrapper')
+        if (this.checked) {
+            wrapper.show(options)
+        } else {
+            wrapper.hide(options)
+        }
+    })
+
     // Initialize dataTable in statistics sidebar
     //   - turn off sorting for the 'icon' column
     //   - initially sort 'name' column alphabetically

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3160,6 +3160,8 @@ $(function () {
         })
 
         $selectLocationIconMarker.val(Store.get('locationMarkerStyle')).trigger('change')
+
+        initFavoriteLocations()
     })
 })
 

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -582,6 +582,134 @@ function initSidebar() {
     }
 
     $('#pokemon-icon-size').val(Store.get('iconSizeModifier'))
+
+    $('#add-favorite-location-button').on('click', function () {
+        var loc = map.getCenter()
+        var zoom = map.getZoom()
+        var name = $('#add-favorite-location-input').val()
+        addFarvoritLocationToSettings(name, loc.lat(), loc.lng(), zoom)
+        $('#add-favorite-location-input').val('')
+    })
+
+    var searchLocationInput = document.getElementById('search-favorite-location-input')
+    if (searchLocationInput) {
+        var googleSearchBox = new google.maps.places.Autocomplete(searchLocationInput)
+
+        googleSearchBox.addListener('place_changed', function () {
+            var place = googleSearchBox.getPlace()
+
+            if (!place.geometry) {
+                return
+            }
+
+            var loc = place.geometry.location
+            centerMap(loc.lat(), loc.lng(), 16)
+        })
+    }
+}
+
+/**
+ * Favorite-location
+ * first run load locations from settings / localStorage
+*/
+function initFavoriteLocations() {
+    var favoriteLocationSettings = Store.get('favoriteLocations')[0]
+
+    if (!favoriteLocationSettings) {
+        return
+    }
+
+    Object.keys(favoriteLocationSettings).forEach(function (locationName) {
+        addFavoriteLocationToList(locationName,
+                                 favoriteLocationSettings[locationName]['lat'],
+                                 favoriteLocationSettings[locationName]['lng'],
+                                 favoriteLocationSettings[locationName]['zoom'],
+                                 favoriteLocationSettings[locationName]['deletable']
+                                )
+    })
+}
+
+/**
+ * Favorite-location
+ * add buttons to the navigation
+ *
+ * @param String name
+ * @param long lat – degree of latitude
+ * @param long lng – degree of longitude
+ * @param int zoom – zoomLevel
+ * @param boolean withDeleteButton (optional – default = true)
+*/
+function addFavoriteLocationToList(name, lat, lng, zoom, withDeleteButton = true) {
+    var li = document.createElement('li')
+    li.setAttribute('name', name)
+
+    var favoriteLocationButton = document.createElement('button')
+    if (!withDeleteButton) { favoriteLocationButton.setAttribute('class', 'favorite-location-no-delete-button') }
+    favoriteLocationButton.innerHTML = name
+    favoriteLocationButton.addEventListener('click', function () {
+        centerMap(lat, lng, parseInt(zoom))
+    })
+    li.appendChild(favoriteLocationButton)
+
+    if (withDeleteButton) {
+        var favoriteLocationDeleteButton = document.createElement('button')
+        favoriteLocationDeleteButton.setAttribute('class', 'delete-favorite-location-button')
+        favoriteLocationDeleteButton.innerHTML = '<span class="fa fa-times"></span>'
+        favoriteLocationDeleteButton.addEventListener('click', function () {
+            confirm('Are you sure to delete "' + name + '"?') ? deleteFavoriteLocation(li) : false
+        })
+        li.appendChild(favoriteLocationDeleteButton)
+    }
+
+    var favoriteLocationListElement = document.getElementById('favorite-location-ul')
+    favoriteLocationListElement.appendChild(li)
+}
+
+/**
+ * Favorite-location
+ * delete location from localStorage and navigation
+ *
+ * @param HTMLelement li
+ */
+function deleteFavoriteLocation(li) {
+    var favoriteLocationSettings = Store.get('favoriteLocations')
+    delete favoriteLocationSettings[0][li.getAttribute('name')]
+    Store.set('favoriteLocations', favoriteLocationSettings)
+
+    var favoriteLocationListElement = document.getElementById('favorite-location-ul')
+    favoriteLocationListElement.removeChild(li)
+    toastr.success('"' + li.getAttribute('name') + '" is deleted', 'Favorite location', {closeButton: true, timeOut: 2500})
+}
+
+/**
+ * Favorite-location
+ * save location in the settings / localStorage and add it in the navigation
+ *
+ * @param String name
+ * @param long lat – degree of latitude
+ * @param long lng – degree of longitude
+ * @param int zoom – zoomLevel
+ * @param boolean withDeleteButton (optional – default = true)
+*/
+function addFarvoritLocationToSettings(name, lat, lng, zoom, withDeleteButton = true) {
+    var favoriteLocationSettings = Store.get('favoriteLocations')
+
+    if (!name || name.length === 0 || !name.trim() || /^\s*$/.test(name)) {
+        toastr.error('Please enter a valid name', 'Failed to create the view', {closeButton: true})
+        return
+    }
+
+    if (favoriteLocationSettings.length === 0) {
+        favoriteLocationSettings[0] = Object.create(Object.prototype)
+    } else if (favoriteLocationSettings[0][name] !== undefined) {
+        toastr.error('Name is already used', 'Failed to create the view', {closeButton: true})
+        return
+    }
+
+    favoriteLocationSettings[0][name] = {'lat': lat, 'lng': lng, 'zoom': zoom, 'deletable': withDeleteButton}
+    Store.set('favoriteLocations', favoriteLocationSettings)
+    addFavoriteLocationToList(name, lat, lng, zoom, withDeleteButton)
+    toastr.success('New view has been saved', 'Favorite location', {closeButton: true, timeOut: 2000})
 }
 
 function getTypeSpan(type) {

--- a/static/sass/layout/_nav.scss
+++ b/static/sass/layout/_nav.scss
@@ -138,4 +138,49 @@
     .fa-fw {
       margin: 0px 5px 0px 0px;
     }
+      
+    #favorite-location-ul {
+      list-style: disc;
+      padding-left: 0!important;
+
+      > li {
+	       list-style: none;
+         width: 50%;
+         float: left;
+         padding-left: 0;
+
+      > .delete-favorite-location-button {
+	       background-color: red;
+	       color: #fff;
+	       width: 14.2%;
+	       margin-left: .8%;
+      }
+
+      > button {
+          width: 85%;
+          overflow: hidden;
+          font-size: 13px;
+          font-weight: normal;
+          margin-top: .5em;
+
+          &.favorite-location-no-delete-button {
+             width: 100%;
+          }
+        }
+      }
+
+      > li:nth-child(2n) {
+        padding-left: .5em;
+      }
+    }
+
+    #add-favorite-location-input {
+      width: 80%;
+      float: left;
+    }
+
+    #add-favorite-location-button {
+      width: 20%;
+      margin-top: 0;
+    }
   }

--- a/templates/map.html
+++ b/templates/map.html
@@ -557,6 +557,46 @@
               </div>
           </div>
             {% endif %}
+
+          <h3><i class="fa fa-binoculars fa-fw"></i>Favorite locations</h3>
+          <div>
+            <div class="form-control switch-container">
+              <h3>Search location</h3>
+              <div class="onoffswitch">
+                <input id="search-favorite-location-switch" type="checkbox" name="search-favorite-location-switch" class="onoffswitch-checkbox">
+                <label class="onoffswitch-label" for="search-favorite-location-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" id="search-favorite-location-wrapper" style="display:none">
+              <div class="form-control">
+                <input id="search-favorite-location-input" type="text" name="search-favorite-location-input" placeholder="Street or City" autocomplete="off">
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <h3>Save this view</h3>
+              <div class="onoffswitch">
+                <input id="add-favorite-location-switch" type="checkbox" name="add-favorite-location-switch" class="onoffswitch-checkbox">
+                <label class="onoffswitch-label" for="add-favorite-location-switch">
+                  <span class="switch-label" data-on="On" data-off="Off"></span>
+                  <span class="switch-handle"></span>
+                </label>
+              </div>
+            </div>
+            <div class="form-control switch-container" id="add-favorite-location-wrapper" style="display:none">
+              <div class="form-control">
+                <input id="add-favorite-location-input" type="text" name="add-favorite-location-input" placeholder="Location Name" maxlength="14"/>
+                <button id="add-favorite-location-button" type="submit"><span class="fa fa-save"></span></button>
+              </div>
+            </div>
+            <div class="form-control switch-container">
+              <ul id="favorite-location-ul">
+              </ul>
+            </div>
+          </div>
+
           <h3><i class="fa fa-map-o fa-fw"></i>Style Settings</h3>
           <div>
             <div class="form-control switch-container">


### PR DESCRIPTION
This will insert a new menu item "Favorite Locations" in the navigation with three functions:

- with the first function, users can search for places like neighborhoods, streets, etc. (This code was already in RM. I only changed it a bit.)

- the second function allows the user to save the current view as "quick button". Each view can be assigned an own name. This buttons can be deleted again at any time by the user.

- and the third feature allows the site admins to leave predefined locations as "quick button". These can be stored as deletable or non-deletable buttons. The predefined gps coordinates are stored in the custom.js

These functions are very helpful to save hotspots like nests, or if the site admin scans only some places (or a large area), he can deposit these places as a "quick button". The places created by the user are stored in the localstorage and will not be publicly available. Therefore, my other PR (#2545) is very useful to restore the settings in case of loss.

A few examples:
(result see Screenshots)

```javascript
const 'favoriteLocations' = [{
        'Amsterdam': {lat: 52.3702157, lng: 4.8951678, zoom: 13, deletable: false},
        'Central Park (NY)': {lat: 40.7828647, lng: -73.9653551, zoom: 16, deletable: false},
        'London': {lat: 51.5073509, lng: -0.1277582, zoom: 14, deletable: true},
        'Berlin': {lat: 52.5200065, lng: 13.4049539, zoom: 14}
    }]
```

![image](https://user-images.githubusercontent.com/21128187/38001080-351ae3b2-322b-11e8-94ba-5a9ed747d3a4.png)
