### PR TITLE
Removes sprite images (Bulbasaur) from 'Rarity notifications'-dropdown

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -3247,8 +3247,7 @@ $(function () {
         })
         $selectRarityNotify.select2({
             placeholder: i8ln('Select Rarity'),
-            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare'), i8ln('New Spawn')],
-            templateResult: formatState
+            data: [i8ln('Common'), i8ln('Uncommon'), i8ln('Rare'), i8ln('Very Rare'), i8ln('Ultra Rare'), i8ln('New Spawn')]
         })
         
 $('.list').on('click', '.pokemon-icon-sprite', function() {


### PR DESCRIPTION
This made no sense and was bugged when using `generate-images` + `pogo-assets`