### PR TITLE
Bring navbar back

### DIFF
--- a/templates/map.html
+++ b/templates/map.html
@@ -54,7 +54,7 @@
 
               {% if show.pokemons %}
             <div class="form-control switch-container">
-              <h3>PokÃ©mon</h3>
+              <h3>Pokémon</h3>
               <div class="onoffswitch">
                 <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokemon-switch">
@@ -257,7 +257,7 @@
               {% endif %}
               {% if show.pokestops %}
             <div class="form-control switch-container">
-              <h3>PokÃ©stops</h3>
+              <h3>Pokéstops</h3>
               <div class="onoffswitch">
                 <input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokestops-switch">
@@ -305,7 +305,7 @@
             </div>
               {% if show.pokemons %}
             <div class="form-control">
-            <h3>Hide PokÃ©mon</h3>
+            <h3>Hide Pokémon</h3>
               <label for="exclude-pokemon">
               <div class=pokemon-container>
                 <input id="exclude-pokemon" type="text" readonly="true" style="display:none;" >
@@ -328,7 +328,7 @@
 			
 				{% if show.encounter %}
             <div class="form-control switch-container">
-              <h3>PokÃ©mon Stats</h3>
+              <h3>Pokémon Stats</h3>
               <div class="onoffswitch">
                 <input id="pokemon-stats-switch" type="checkbox" name="pokemon-stats-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokemon-stats-switch">
@@ -454,7 +454,7 @@
           <h3><i class="fa fa-bullhorn fa-fw"></i>Notification Settings</h3>
           <div>
             <div class="form-control">
-            <h3>Notify of PokÃ©mon</h3>
+            <h3>Notify of Pokémon</h3>
               <label for="notify-pokemon">
               <div class=pokemon-container>
                 <input id="notify-pokemon" type="text" readonly="true" style="display:none;" >
@@ -562,7 +562,7 @@
               </div>
             </div>
               <div class="form-control switch-container">
-              <h3>Use PokÃ©mon cries</h3>
+              <h3>Use Pokémon cries</h3>
                 <div class="onoffswitch">
                 <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
                   <label class="onoffswitch-label" for="cries-switch">

--- a/templates/map.html
+++ b/templates/map.html
@@ -44,9 +44,7 @@
       <!-- Header -->
       <header id="header">
         <a href="#nav"><span class="label">Options</span></a>
-        <h1><a href="./"><img class='rocket icon' src='static/images/rocket.png'></a></h1>
-        <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
-        <span id="weatherInfo" style="float: right; vertical-align: middle;"></span>
+		        {% include 'web_header_links.txt' %}
       </header>
       <!-- NAV -->
       <nav id="nav">
@@ -56,7 +54,7 @@
 
               {% if show.pokemons %}
             <div class="form-control switch-container">
-              <h3>Pokémon</h3>
+              <h3>PokÃ©mon</h3>
               <div class="onoffswitch">
                 <input id="pokemon-switch" type="checkbox" name="pokemon-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokemon-switch">
@@ -259,7 +257,7 @@
               {% endif %}
               {% if show.pokestops %}
             <div class="form-control switch-container">
-              <h3>Pokéstops</h3>
+              <h3>PokÃ©stops</h3>
               <div class="onoffswitch">
                 <input id="pokestops-switch" type="checkbox" name="pokestops-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokestops-switch">
@@ -307,7 +305,7 @@
             </div>
               {% if show.pokemons %}
             <div class="form-control">
-            <h3>Hide Pokémon</h3>
+            <h3>Hide PokÃ©mon</h3>
               <label for="exclude-pokemon">
               <div class=pokemon-container>
                 <input id="exclude-pokemon" type="text" readonly="true" style="display:none;" >
@@ -330,7 +328,7 @@
 			
 				{% if show.encounter %}
             <div class="form-control switch-container">
-              <h3>Pokémon Stats</h3>
+              <h3>PokÃ©mon Stats</h3>
               <div class="onoffswitch">
                 <input id="pokemon-stats-switch" type="checkbox" name="pokemon-stats-switch" class="onoffswitch-checkbox" checked>
                 <label class="onoffswitch-label" for="pokemon-stats-switch">
@@ -456,7 +454,7 @@
           <h3><i class="fa fa-bullhorn fa-fw"></i>Notification Settings</h3>
           <div>
             <div class="form-control">
-            <h3>Notify of Pokémon</h3>
+            <h3>Notify of PokÃ©mon</h3>
               <label for="notify-pokemon">
               <div class=pokemon-container>
                 <input id="notify-pokemon" type="text" readonly="true" style="display:none;" >
@@ -564,7 +562,7 @@
               </div>
             </div>
               <div class="form-control switch-container">
-              <h3>Use Pokémon cries</h3>
+              <h3>Use PokÃ©mon cries</h3>
                 <div class="onoffswitch">
                 <input id="cries-switch" type="checkbox" name="cries-switch" class="onoffswitch-checkbox" checked>
                   <label class="onoffswitch-label" for="cries-switch">
@@ -723,4 +721,4 @@
     <script defer src="https://maps.googleapis.com/maps/api/js?key={{ gmaps_key }}&amp;callback=initMap&amp;libraries=places,geometry"></script>
     <script async src='https://www.google-analytics.com/analytics.js'></script>
   </body>
-</html>
+</html> 

--- a/templates/web_header_links.txt
+++ b/templates/web_header_links.txt
@@ -1,0 +1,510 @@
+<style>
+.dropbtn {
+    margin: 0 0 0 0;
+//    background-color: #4CAF50;
+    color: white;
+    font-size: 1.00em;
+    height: 1.50em;
+    line-height: 1.50em;
+    padding: 2px 10px 2px 10px;
+    border: none;
+    cursor: pointer;
+}
+
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: #f9f9f9;
+    font-size: 0.8em;
+    line-height: 1.9em;
+    min-width: 180px;
+    box-shadow: 0px 0px 0px 0px rgba(0,0,0,0.2);
+    z-index: 1;
+    right: 0;
+    overflow: scroll;
+    height: 190px;
+}
+
+.dropdown-content a {
+    color: black;
+    padding: 1px 16px;
+    text-decoration: none;
+    white-space: nowrap;
+    width: 100%;
+    display: inline-block;
+}
+
+.dropdown-content a:hover {background-color: #ddd}
+
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+.dropdown:hover .dropbtn {
+    background-color: #3e8e41;
+}
+</style>
+
+<h1><a href="./"><img class='rocket icon' src='static/images/rocket.png'></a></h1>
+<h1>
+        
+          
+<div class="dropdown">
+  <button class="dropbtn"><i class="fa fa-filter" title="Filter Pokemon"></i></button>
+  <div class="dropdown-content" style="left:0;min-width:225px;">
+                  <a href="javascript:hideall();     ">All Pokemon Off</a>
+                  <a href="javascript:showall();     ">All Pokemon On</a>
+				  <a href="javascript:onlyshiny();     ">Possible shinies</a>
+                  <a href="javascript:onlygen1();    ">Gen1 Only</a>
+                  <a href="javascript:onlygen2();    ">Gen2 Only</a>
+                  <a href="javascript:onlygen3();    ">Gen3 Only</a>
+                  <a href="javascript:hidegen1();    ">Turn Off Gen1</a>
+                  <a href="javascript:hidegen2();    ">Turn Off Gen2</a>
+                  <a href="javascript:hidegen3();    ">Turn Off Gen3</a>
+                  <a href="javascript:showgen1();    ">Turn On Gen1</a>
+                  <a href="javascript:showgen2();    ">Turn On Gen2</a>
+                  <a href="javascript:showgen3();    ">Turn On Gen3</a>
+                  <a href="javascript:showevo();    ">Show Evolutions Only</a>
+  </div>
+</div>
+
+<div class="dropdown">
+  <button class="dropbtn"><i class="fa fa-cloud" title="Filter by weather"></i></button>
+  <div class="dropdown-content" style="left:-100px;min-width:325px;">
+                  <a href="javascript:hideall();      ">All Pokemon Off</a>
+                  <a href="javascript:showall();      ">All Pokemon On</a>
+                  <a href="javascript:weather(sunny); ">Weather Pokemon: Sunny</a>
+                  <a href="javascript:weather(partly);">Weather Pokemon: Partly Cloudy</a>
+                  <a href="javascript:weather(cloudy);">Weather Pokemon: Cloudy</a>
+                  <a href="javascript:weather(windy); ">Weather Pokemon: Windy</a>
+                  <a href="javascript:weather(rainy); ">Weather Pokemon: Rainy</a>
+                  <a href="javascript:weather(snow);  ">Weather Pokemon: Snow</a>
+                  <a href="javascript:weather(fog);   ">Weather Pokemon: Fog</a>
+  </div>
+</div>
+
+<div class="dropdown">
+  <button class="dropbtn"><i class="fa fa-leaf" title="Filter by type"></i></button>
+  <div class="dropdown-content" style="left:-150px;min-width:225px;">
+                  <a href="javascript:hideall();      ">All Pokemon Off</a>
+                  <a href="javascript:showall();      ">All Pokemon On</a>
+                  <a href="javascript:showdragon(); ">Dragon types only</a>
+                  <a href="javascript:showwater(); ">Water types only</a>
+                  <a href="javascript:showsteel(); ">Steel types only</a>
+                  <a href="javascript:showfire(); ">Fire types only</a>
+                  <a href="javascript:showrock(); ">Rock types only</a>
+                  <a href="javascript:showdark(); ">Dark types only</a>
+                  <a href="javascript:showbug(); ">Bug types only</a>
+                  <a href="javascript:showground(); ">Ground types only</a>
+                  <a href="javascript:shownormal(); ">Normal types only</a>
+                  <a href="javascript:showfight(); ">Fighting types only</a>
+                  <a href="javascript:showghost(); ">Ghost types only</a>
+                  <a href="javascript:showpsychic(); ">Psychic types only</a>
+                  <a href="javascript:showflying(); ">Flying types only</a>
+                  <a href="javascript:showgrass(); ">Grass types only</a>
+                  <a href="javascript:showpoison(); ">Poison types only</a>
+                  <a href="javascript:showelectric(); ">Electric types only</a>
+                  <a href="javascript:showfairy(); ">Fairy types only</a>
+                  <a href="javascript:showice(); ">Ice types only</a>
+  </div>
+</div>
+
+<div class="dropdown">
+  <button class="dropbtn"><i class="fa fa-shield" title="Filter by skill"></i></button>
+  <div class="dropdown-content" style="left:-150px;min-width:225px;">
+                  <a href="javascript:hideall();      ">All Pokemon Off</a>
+                  <a href="javascript:showall();      ">All Pokemon On</a>
+                  <a href="javascript:showattack(); ">Best attackers</a>
+                  <a href="javascript:showdefense(); ">Best defenders</a>
+                  <a href="javascript:showstier(); ">S-Tier Only</a>
+                  <a href="javascript:showstart(); ">Starters Only</a>
+                  <a href="javascript:showsnoep(); ">400 Candy Only</a>
+  </div>
+</div>
+
+
+</h1>
+
+        <a href="#stats" id="statsToggle" class="statsNav" style="float: right;"><span class="label">Stats</span></a>
+        <span id="weatherInfo" style="float: right; vertical-align: middle;"></span>
+
+<script src="{{ url_for('static', filename='dist/js/weather.min.js').lstrip('/') }}"></script>
+<script>
+var gen1 = [1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103,104,105,106,107,108,109,110,111,112,113,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,130,131,132,133,134,135,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151];
+var gen2 = [152,153,154,155,156,157,158,159,160,161,162,163,164,165,166,167,168,169,170,171,172,173,174,175,176,177,178,179,180,181,182,183,184,185,186,187,188,189,190,191,192,193,194,195,196,197,198,199,200,201,202,203,204,205,206,207,208,209,210,211,212,213,214,215,216,217,218,219,220,221,222,223,224,225,226,227,228,229,230,231,232,233,234,235,236,237,238,239,240,241,242,243,244,245,246,247,248,249,250,251];
+var gen3 = [252,253,254,255,256,257,258,259,260,261,262,263,264,265,266,267,268,269,270,271,272,273,274,275,276,277,278,279,280,281,282,283,284,285,286,287,288,289,290,291,292,293,294,295,296,297,298,299,300,301,302,303,304,305,306,307,308,309,310,311,312,313,314,315,316,317,318,319,320,321,322,323,324,325,326,327,328,329,330,331,332,333,334,335,336,337,338,339,340,341,342,343,344,345,346,347,348,349,350,351,352,353,354,355,356,357,358,359,360,361,362,363,364,365,366,367,368,369,370,371,372,373,374,375,376,377,378,379,380,381,382,383,384,385,386];
+var sunny = [1,2,3,4,5,6,27,28,31,34,37,38,43,44,45,46,47,50,51,58,59,69,70,71,74,75,76,77,78,95,102,103,104,105,111,112,114,126,136,146,152,153,154,155,156,157,182,187,188,189,191,192,194,195,207,208,218,219,220,221,228,229,231,232,240,244,246,247,250,251,252,253,254,255,256,257,259,260,270,271,272,273,274,275,285,286,290,315,322,322,323,323,324,328,329,330,331,332,339,340,343,344,345,346,357,383,387,388,389,389,390,391,392,406,407,413,420,421,423,443,444,445,449,450,455,459,460,464,465,467,470,472,473,485,492,494,495,496,497,498,499,500,511,512,513,514,529,530,536,537,540,541,542,546,547,548,549,551,552,553,554,555,556,585,586,590,591,597,598,607,608,609,618,622,623,631,636,637,640,643,645,650,651,652,653,654,655,660,662,663,667,668,672,673,708,709,710,711,718];
+var partly = [16,17,18,19,20,21,22,39,40,52,53,74,75,76,83,84,85,95,108,111,112,113,115,128,132,133,137,138,139,140,141,142,143,161,162,163,164,174,185,190,203,206,213,216,217,219,222,233,234,235,241,242,246,247,248,263,264,276,277,287,288,289,293,294,295,298,299,300,301,304,305,306,327,333,335,337,338,345,346,347,348,351,352,369,377,396,397,398,399,400,408,409,410,411,424,427,428,431,432,438,440,441,446,463,464,474,476,486,493,504,505,506,507,508,519,520,521,524,525,526,531,557,558,564,565,566,567,572,573,585,586,626,627,628,639,648,659,660,661,667,668,676,688,689,694,695,696,697,698,699,703,719];
+var cloudy = [1,2,3,13,14,15,23,24,29,30,31,32,33,34,35,36,39,40,41,42,43,44,45,48,49,56,57,62,66,67,68,69,70,71,72,73,88,89,92,93,94,106,107,109,110,122,167,168,169,173,174,175,176,183,184,209,210,211,214,236,237,256,257,269,280,281,282,286,296,297,298,303,307,308,315,316,317,336,391,392,406,407,434,435,439,447,448,451,452,453,453,454,454,468,475,499,500,532,533,534,538,539,543,544,545,546,547,559,560,568,569,590,591,619,620,638,639,640,647,652,669,670,671,674,675,682,683,684,685,690,691,700,701,702,703,707,716,719];
+var rainy = [7,8,9,10,11,12,13,14,15,25,26,46,47,48,49,54,55,60,61,62,72,73,79,80,81,82,86,87,90,91,98,99,100,101,116,117,118,119,120,121,123,125,127,129,130,131,134,135,138,139,140,141,145,158,159,160,165,166,167,168,170,170,171,171,172,179,180,181,183,184,186,193,194,195,199,204,205,211,212,213,214,222,223,224,226,230,239,243,245,258,259,260,265,266,267,268,269,270,271,272,278,279,283,283,284,290,291,292,309,310,311,312,313,314,318,319,320,321,339,340,341,342,347,348,349,350,363,364,365,366,367,368,369,370,382,393,394,395,400,401,402,403,404,405,412,413,414,415,416,417,418,419,422,423,451,456,457,458,462,466,469,479,484,489,490,501,502,503,515,516,522,523,535,536,537,540,541,542,543,544,545,550,557,558,564,565,580,581,587,588,589,592,593,594,595,595,596,596,602,603,604,616,617,618,632,636,637,642,644,647,649,656,657,658,664,665,666,688,689,690,692,693,694,695,702];
+var snow = [81,82,87,91,124,131,144,205,208,212,215,220,221,225,227,238,303,304,305,306,361,362,363,364,365,374,375,376,378,379,385,395,410,411,436,437,448,459,460,461,462,471,473,476,478,483,485,530,582,583,584,589,597,598,599,600,601,613,614,615,624,625,632,638,646,649,679,680,681,698,699,707,712,713];
+var fog = [92,93,94,197,198,200,215,228,229,248,261,262,274,275,292,302,302,318,319,332,342,353,354,355,356,359,425,426,429,430,434,435,442,442,452,461,477,478,479,487,491,509,510,551,552,553,559,560,562,563,570,571,592,593,607,608,609,622,623,624,625,629,630,633,634,635,658,675,679,680,681,686,687,708,709,710,711,717,720];
+var windy = [6,12,16,17,18,21,22,41,42,63,64,65,79,80,83,84,85,96,97,102,103,121,122,123,124,130,142,144,145,146,147,148,149,150,151,163,164,165,166,169,176,177,177,178,178,187,188,189,193,196,198,199,201,202,203,207,225,226,227,230,238,249,249,250,251,267,276,277,278,279,280,281,282,284,291,307,308,325,326,329,330,333,334,334,337,338,343,344,357,358,360,371,372,373,373,374,375,376,380,380,381,381,384,384,385,386,396,397,398,414,415,416,425,426,430,433,436,437,439,441,443,444,445,458,468,469,472,475,480,481,482,483,484,487,488,494,517,518,519,520,521,527,527,528,528,561,561,566,567,574,575,576,577,578,579,580,581,587,605,606,610,611,612,621,627,628,629,630,633,634,635,641,642,643,644,645,646,648,655,661,662,663,666,677,678,686,687,691,696,697,701,704,705,706,714,714,715,715,717,718,720];
+
+function updatePokemon() {
+    if (Store.get('showPokemon') === false) {
+        Store.set('showPokemon', true)
+        location.reload();
+    }
+    else {
+        redrawPokemon(mapData.pokemons);
+        redrawPokemon(mapData.lurePokemons);
+    }
+}
+function showall(){
+	$selectExclude.val([]).trigger('change');
+    updatePokemon();
+}
+function hideall(){
+    exclude = gen1.concat(gen2)
+    exclude = exclude.concat(gen3)
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+function onlyrares(){
+    exclude = [1,2,4,5,7,8,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,29,30,32,33,35,37,39,41,42,43,44,46,47,48,49,50,51,52,53,54,56,58,60,61,63,64,66,69,70,72,73,74,75,77,79,81,83,84,85,86,88,90,92,93,95,96,98,99,100,101,102,103,104,105,108,109,110,111,114,115,116,117,118,119,120,121,122,123,124,125,126,127,128,129,132,133,137,138,140,152,153,155,158,161,162,163,164,165,166,167,168,169,170,177,178,181,182,183,184,185,187,188,190,191,193,194,195,198,200,202,203,204,205,206,207,209,211,213,215,216,217,218,220,221,222,223,224,226,227,228,231,233,234,302,355];
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+function onlyshiny(){
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    shiny = [1,25,129,147,148,149,261,262,353,355,302,304,333,361,362,370];
+    $selectExclude.val(excludeall.diff(shiny.map(String))).trigger('change');
+    updatePokemon();
+}
+function onlygen1(){
+    exclude = gen2.concat(gen3)
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+function onlygen2(){
+    exclude = gen1.concat(gen3)
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+function onlygen3(){
+    exclude = gen1.concat(gen2)
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+function hidegen1(){
+    current = $selectExclude.val();
+    exclude = gen1;
+    $selectExclude.val(current.concat(exclude)).trigger('change');
+    updatePokemon();
+}
+function hidegen2(){
+    current = $selectExclude.val();
+    exclude = gen2;
+    $selectExclude.val(current.concat(exclude)).trigger('change');
+    updatePokemon();
+}
+function hidegen3(){
+    current = $selectExclude.val();
+    exclude = gen3;
+    $selectExclude.val(current.concat(exclude)).trigger('change');
+    updatePokemon();
+}
+
+function showgen1(){
+    current = $selectExclude.val();
+    include = gen1;
+    $selectExclude.val(current.diff(include.map(String))).trigger('change');
+    updatePokemon();
+}
+function showgen2(){
+    current = $selectExclude.val();
+    include = gen2;
+    $selectExclude.val(current.diff(include.map(String))).trigger('change');
+    updatePokemon();
+}
+function showgen3(){
+    current = $selectExclude.val();
+    include = gen3;
+    $selectExclude.val(current.diff(include.map(String))).trigger('change');
+    updatePokemon();
+}
+function showdratini(){
+    current = $selectExclude.val();
+    include = [147,148,149];
+    $selectExclude.val(current.diff(include.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showdragon(){
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    dragon = [147,148,149,230,329,330,334,371,372,373,380,381,384];
+    $selectExclude.val(excludeall.diff(dragon.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showwater(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    water = [7,8,9,54,55,60,61,62,72,73,79,80,86,87,90,91,98,99,116,117,118,119,120,121,129,130,131,134,138,139,140,141,158,159,160,170,171,183,184,186,194,195,199,211,222,223,224,226,230,245,258,259,260,270,271,272,278,279,283,318,319,320,321,339,340,341,342,349,350,363,364,365,366,367,368,369,370,382];
+    $selectExclude.val(excludeall.diff(water.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showsteel(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    steel = [81,82,205,208,212,227,303,304,305,306,374,375,376,379,385];
+    $selectExclude.val(excludeall.diff(steel.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showfire(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    fire = [4,5,6,37,38,58,59,77,78,126,136,146,155,156,157,218,219,228,229,240,244,250,255,256,257,322,323,324];
+    $selectExclude.val(excludeall.diff(fire.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showrock(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    rock = [74,75,76,95,111,112,138,139,140,141,142,185,213,219,222,246,247,248,299,304,305,306,337,338,345,346,347,348,369,377];
+    $selectExclude.val(excludeall.diff(rock.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showdark(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    dark = [197,198,215,228,229,248,261,262,274,275,302,318,319,332,342,359];
+    $selectExclude.val(excludeall.diff(dark.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showbug(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    bug = [10,11,12,13,14,15,46,47,48,49,123,127,165,166,167,168,193,204,205,212,213,214,265,266,267,268,269,283,284,290,291,292,313,314,347,348];
+    $selectExclude.val(excludeall.diff(bug.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showground(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    ground = [27,28,31,34,50,51,74,75,76,95,104,105,111,112,194,195,207,208,220,221,231,232,246,247,259,260,290,322,323,328,329,330,339,340,343,344,383];
+    $selectExclude.val(excludeall.diff(ground.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function shownormal(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    normal = [16,17,18,19,20,21,22,39,40,52,53,83,84,85,108,113,115,128,132,133,137,143,161,162,163,164,174,190,203,206,216,217,233,234,235,241,242,263,264,276,277,287,288,289,293,294,295,298,300,301,327,333,335,351,352];
+    $selectExclude.val(excludeall.diff(normal.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showfight(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    fight = [56,57,62,66,67,68,106,107,214,236,237,256,257,286,296,297,307,308];
+    $selectExclude.val(excludeall.diff(fight.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showghost(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    ghost = [92,93,94,200,292,302,353,354,355,356];
+    $selectExclude.val(excludeall.diff(ghost.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showpsychic(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    psychic = [63,64,65,79,80,96,97,102,103,121,122,124,150,151,177,178,196,199,201,202,203,238,249,251,280,281,282,307,308,325,326,337,338,343,344,358,360,374,375,376,380,381,385,386];
+    $selectExclude.val(excludeall.diff(psychic.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showflying(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    flying = [6,12,16,17,18,21,22,41,42,83,84,85,123,130,142,144,145,146,149,163,164,165,166,169,176,177,178,187,188,189,193,198,207,225,226,227,249,250,267,276,277,278,279,284,291,333,334,357,373,384];
+    $selectExclude.val(excludeall.diff(flying.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showgrass(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    grass = [1,2,3,43,44,45,46,47,69,70,71,102,103,114,152,153,154,182,187,188,189,191,192,251,252,253,254,270,271,272,273,274,275,285,286,315,331,332,345,346,357];
+    $selectExclude.val(excludeall.diff(grass.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showpoison(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    poison = [1,2,3,13,14,15,23,24,29,30,31,32,33,34,41,42,43,44,45,48,49,69,70,71,72,73,88,89,92,93,94,109,110,167,168,169,211,269,315,316,317,336];
+    $selectExclude.val(excludeall.diff(poison.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showelectric(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    electric = [25,26,81,82,100,101,125,135,145,170,171,172,179,180,181,239,243,309,310,311,312];
+    $selectExclude.val(excludeall.diff(electric.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showfairy(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    fairy = [35,36,39,40,122,173,174,175,176,183,184,209,210,280,281,282,298,303];
+    $selectExclude.val(excludeall.diff(fairy.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showice(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    ice = [87,91,124,131,144,215,220,221,225,238,361,362,363,364,365,378];
+    $selectExclude.val(excludeall.diff(ice.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showattack(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    attack = [212,127,248,229,149,373,135,282,68,297,136,6,94,103,254,112,124,221,91,365,131,143,89,65,196,76,139,376,130,134];
+    $selectExclude.val(excludeall.diff(attack.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showdefense(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    defense = [242,113,143,350,149,289,208,232,131,171,282,36,103,3,376];
+    $selectExclude.val(excludeall.diff(defense.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showstier(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    stier = [2,3,5,6,8,9,31,34,35,36,38,45,51,55,57,59,62,63,64,65,66,67,68,71,77,78,76,89,91,93,94,103,112,113,124,127,130,131,132,134,135,136,138,139,140,141,142,143,147,148,149,153,154,156,157,159,160,171,180,181,182,196,208,212,229,231,232,242,246,247,248,252,253,254,257,260,274,282,287,288,289,297,304,305,306,328,329,330,350,365,371,372,373,374,375,376,114,175,176,186,197,199,201,210,230,241,256,259,284];
+    $selectExclude.val(excludeall.diff(stier.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showstart(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    start = [1,4,7,25,152,155,158,252,255,258];
+    $selectExclude.val(excludeall.diff(start.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showsnoep(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    snoep = [129,320,333];
+    $selectExclude.val(excludeall.diff(snoep.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function showevo(){
+
+    excludeall = gen1.concat(gen2)
+    excludeall = excludeall.concat(gen3)
+    excludeall = excludeall.map(String)
+    evo = [2,3,5,6,8,9,11,12,14,15,17,18,20,22,24,26,28,30,31,33,34,36,38,40,42,44,45,47,49,51,53,55,57,59,61,62,64,65,67,68,70,71,73,75,76,78,80,82,85,87,89,91,93,94,95,97,99,101,103,105,106,107,108,110,112,114,115,117,119,121,123,124,125,126,127,128,130,131,132,133,134,135,136,137,139,141,142,143,144,145,146,148,149,150,151,153,154,156,157,159,160,162,164,166,168,169,171,172,173,174,175,176,178,180,181,182,184,186,188,189,190,192,193,195,196,197,199,201,205,207,208,210,212,214,215,217,219,221,222,224,225,227,229,230,232,233,235,236,237,238,239,240,241,242,243,244,245,247,248,249,250,251,253,254,256,257,259,260,262,264,266,267,268,269,271,272,274,275,277,279,281,282,284,286,288,289,291,292,294,295,297,298,299,301,302,303,305,306,308,310,315,317,319,321,323,324,326,327,329,330,332,334,335,336,337,338,340,342,344,346,348,349,350,351,352,354,356,357,358,359,360,362,364,365,366,367,368,369,370,372,373,375,376,377,378,379,380,381,382,383,384,385,386];
+    $selectExclude.val(excludeall.diff(evo.map(String))).trigger('change');
+    updatePokemon();
+}
+
+function weather(include){
+    exclude = gen1.concat(gen2)
+    exclude = exclude.concat(gen3)
+    exclude = exclude.diff(include)
+    $selectExclude.val(exclude).trigger('change');
+    updatePokemon();
+}
+
+function showraids(lvlmin, lvlmax){
+    if (lvlmax > 0) {
+        Store.set('showRaidPokemon', "0");
+        Store.set('showRaidMinLevel', lvlmin.toString());
+        Store.set('showRaidMaxLevel', lvlmax.toString());
+        Store.set('showActiveRaidsOnly', false);
+        Store.set('showRaids', true);
+        Store.set('showPokemon', false);
+        location.reload();
+    }
+    else {
+        Store.set('showRaids', false);
+        location.reload();
+    }
+}
+
+Array.prototype.diff = function (a) {
+    return this.filter(function (i) {
+        return a.indexOf(i) === -1;
+    });
+};
+
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
For now the navigationbar-filters only work after a page refresh. we need to trigger a refresh of the pokemon selector after we applied a filter.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Possible fix:

![image](https://user-images.githubusercontent.com/21128187/38480270-f25cffda-3bc4-11e8-8f56-0f9a88e9b283.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
