### PR TITLE
[SenorKarlos PR Port] Adding an option to hide the Pokemon stats

### DIFF
--- a/config/config.ini.example
+++ b/config/config.ini.example
@@ -130,6 +130,7 @@
 #enc-whitelist-file:            # File containing a list of Pokemon IDs to encounter for IV/CPs. Requires L30 or higher accounts in --high-lvl-accounts.
 #hlvl-kph:                      # Set a maximum speed in km/hour for high level account scanning. 0 to disable. (default=25)
 #medalpokemon                   # Show notify for tiny rattata and big magikarp on map
+#hide-encounters                # Hide the encounter stats from the web. (default=False)
 
 # Webserver settings
 ####################

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -159,16 +159,18 @@ class Pokemon(LatLongModel):
         now_date = datetime.utcnow()
 
         if args.hide_encounters:
-        log.info('Encounter stats disabled on front-end.')
+        log.info(
+            'Encounter stats disabled on front-end.'
+        )
         query = Pokemon.select(
-        Pokemon.encounter_id,
-        Pokemon.spawnpoint_id,
-        Pokemon.pokemon_id,
-        Pokemon.latitude,
-        Pokemon.longitude,
-        Pokemon.disappear_time,
-        Pokemon.weather_boosted_condition,
-        Pokemon.last_modified
+            Pokemon.encounter_id,
+            Pokemon.spawnpoint_id,
+            Pokemon.pokemon_id,
+            Pokemon.latitude,
+            Pokemon.longitude,
+            Pokemon.disappear_time,
+            Pokemon.weather_boosted_condition,
+            Pokemon.last_modified
         )
 
         else:

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -159,9 +159,9 @@ class Pokemon(LatLongModel):
         now_date = datetime.utcnow()
 
         if args.hide_encounters:
-		log.info('Encounter stats disabled on front-end.')
-		query = Pokemon.select(
-		Pokemon.encounter_id,
+        log.info('Encounter stats disabled on front-end.')
+        query = Pokemon.select(
+        Pokemon.encounter_id,
         Pokemon.spawnpoint_id,
         Pokemon.pokemon_id,
         Pokemon.latitude,

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -157,7 +157,21 @@ class Pokemon(LatLongModel):
     def get_active(swLat, swLng, neLat, neLng, timestamp=0, oSwLat=None,
                    oSwLng=None, oNeLat=None, oNeLng=None, exclude=None):
         now_date = datetime.utcnow()
-        query = Pokemon.select()
+
+        if args.hide_encounters:
+            query = Pokemon.select(
+                Pokemon.encounter_id,
+                Pokemon.spawnpoint_id,
+                Pokemon.pokemon_id,
+                Pokemon.latitude,
+                Pokemon.longitude,
+                Pokemon.disappear,
+                Pokemon.weather_boosted_condition,
+                Pokemon.last_modified
+            )
+
+        else:
+            query = Pokemon.select()
 
         if exclude:
             query = query.where(Pokemon.pokemon_id.not_in(list(exclude)))

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -159,19 +159,16 @@ class Pokemon(LatLongModel):
         now_date = datetime.utcnow()
 
         if args.hide_encounters:
-        log.info(
-            'Encounter stats disabled on front-end.'
-        )
-        query = Pokemon.select(
-            Pokemon.encounter_id,
-            Pokemon.spawnpoint_id,
-            Pokemon.pokemon_id,
-            Pokemon.latitude,
-            Pokemon.longitude,
-            Pokemon.disappear_time,
-            Pokemon.weather_boosted_condition,
-            Pokemon.last_modified
-        )
+            query = Pokemon.select(
+                Pokemon.encounter_id,
+                Pokemon.spawnpoint_id,
+                Pokemon.pokemon_id,
+                Pokemon.latitude,
+                Pokemon.longitude,
+                Pokemon.disappear,
+                Pokemon.weather_boosted_condition,
+                Pokemon.last_modified
+            )
 
         else:
             query = Pokemon.select()

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -165,7 +165,7 @@ class Pokemon(LatLongModel):
                 Pokemon.pokemon_id,
                 Pokemon.latitude,
                 Pokemon.longitude,
-                Pokemon.disappear,
+                Pokemon.disappear_time,
                 Pokemon.weather_boosted_condition,
                 Pokemon.last_modified
             )

--- a/pogom/models.py
+++ b/pogom/models.py
@@ -159,16 +159,17 @@ class Pokemon(LatLongModel):
         now_date = datetime.utcnow()
 
         if args.hide_encounters:
-            query = Pokemon.select(
-                Pokemon.encounter_id,
-                Pokemon.spawnpoint_id,
-                Pokemon.pokemon_id,
-                Pokemon.latitude,
-                Pokemon.longitude,
-                Pokemon.disappear,
-                Pokemon.weather_boosted_condition,
-                Pokemon.last_modified
-            )
+		log.info('Encounter stats disabled on front-end.')
+		query = Pokemon.select(
+		Pokemon.encounter_id,
+        Pokemon.spawnpoint_id,
+        Pokemon.pokemon_id,
+        Pokemon.latitude,
+        Pokemon.longitude,
+        Pokemon.disappear_time,
+        Pokemon.weather_boosted_condition,
+        Pokemon.last_modified
+        )
 
         else:
             query = Pokemon.select()

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1013,7 +1013,7 @@ def init_args(args):
         log.info("Watching encounter whitelist file {} for changes.".format(
             args.enc_whitelist_file))
         watchercfg['enc_whitelist'] = (args.enc_whitelist_file, None)
-        
+
     # Add logging when hide-encounters is enabled in config.ini
     if args.hide_encounters:
         log.info('Encounter stats disabled on front-end.')

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -173,6 +173,9 @@ def get_args():
     parser.add_argument('-enc', '--encounter',
                         help='Start an encounter to gather IVs and moves.',
                         action='store_true', default=False)
+    parser.add_argument('-hide', '--hide-encounters',
+                        help='Hide the encounter stats from the web',
+                        action='store_true', default=False)
     parser.add_argument('-mpm', '--medalpokemon',
                         help='Show notify for tiny rattata and big magikarp.',
                         action='store_true', default=False)

--- a/pogom/utils.py
+++ b/pogom/utils.py
@@ -1013,6 +1013,10 @@ def init_args(args):
         log.info("Watching encounter whitelist file {} for changes.".format(
             args.enc_whitelist_file))
         watchercfg['enc_whitelist'] = (args.enc_whitelist_file, None)
+        
+    # Add logging when hide-encounters is enabled in config.ini
+    if args.hide_encounters:
+        log.info('Encounter stats disabled on front-end.')
 
     # Prepare webhook whitelist - empty list means no restrictions
     args.webhook_whitelist = []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When encounters are activated, a malicious user can ask for all the statistics, even when the statistics are disabled by configuration in the JavaScript code.

With this change you can be able to hide the stats, so when the frontend asks for the Pokemon, it will return an array of Pokemon with all the statistics removed.

This doesn't affect at all to webhooks or database storage

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--  NOTE: In order to check code style locally and avoid having your build rejected by Travis, -->
<!--  run the following commands before you commit: `flake8 .` and `npm run lint`. Fix any -->
<!--  issues they point out. Note also that flake's NOQA is disabled on Travis. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
